### PR TITLE
0.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LineIntegrals"
 uuid = "2c651c0d-f5be-416b-b771-ab860150eb63"
 authors = ["Mike Ingold <mike.ingold@gmail.com>"]
-version = "0.6.0"
+version = "0.7.0"
 
 [deps]
 FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,29 @@
 # LineIntegrals.jl
 
-This package implements methods for computing line integrals along geometric 1-Dim polytopes
-from [**Meshes.jl**](https://github.com/JuliaGeometry/Meshes.jl). Two sets of methods are
-currently implemented:
-- `integral(f, geometry)` uses Gauss-Legendre quadratures from [**FastGaussQuadrature.jl**](https://github.com/JuliaApproximation/FastGaussQuadrature.jl)
-- `quadgk(f, geometry)` using the adaptive Gauss-Kronrod quadrature rule from [**QuadGK.jl**](https://github.com/JuliaMath/QuadGK.jl)
+This package implements methods for computing integrals over geometric polytopes
+from [**Meshes.jl**](https://github.com/JuliaGeometry/Meshes.jl).
 
-All methods are verified to work with
+Using Gauss-Legendre quadrature rules from [**FastGaussQuadrature.jl**](https://github.com/JuliaApproximation/FastGaussQuadrature.jl):
+- Line integrals
+    - `lineintegral(f, ::Meshes.Point...)`
+    - `lineintegral(f, ::Meshes.Segment)`
+    - `lineintegral(f, ::Meshes.Ring)`
+    - `lineintegral(f, ::Meshes.Rope)`
+    - `lineintegral(f, ::Meshes.BezierCurve)`
+- Surface integrals
+    - `surfaceintegral(g, ::Meshes.Triangle)`
+
+Using the h-adaptive Gauss-Kronrod quadrature rules from [**QuadGK.jl**](https://github.com/JuliaMath/QuadGK.jl):
+- Line integrals
+    - `quadgk_line(f, ::Meshes.Point...)`
+    - `quadgk_line(f, ::Meshes.Segment)`
+    - `quadgk_line(f, ::Meshes.Ring)`
+    - `quadgk_line(f, ::Meshes.Rope)`
+    - `quadgk_line(f, ::Meshes.BezierCurve)`
+- Surface integrals
+    - `quadgk_surface(g, ::Meshes.Triangle)`
+
+Methods are tested to ensure compatibility with
 - Meshes.jl geometries with **Unitful.jl** coordinate types, e.g. `Point(1.0u"m", 2.0u"m")`
 - Meshes.jl geometries with **DynamicQuantities.jl** coordinate types, e.g. `Point(1.0u"m", 2.0u"m")`
 - Any `f(::Meshes.Point{Dim,<:Real})` that maps to a value type that **QuadGK.jl** can integrate, including:
@@ -14,13 +31,6 @@ All methods are verified to work with
     - Real or complex-valued vectors
     - Dimensionful scalars or vectors from Unitful.jl
     - Dimensionful scalars or vectors from DynamicQuantities.jl
-
-Implements `QuadGK.quadgk` methods for
-- `quadgk(f, ::Meshes.Point...) `
-- `quadgk(f, ::Meshes.Segment)`
-- `quadgk(f, ::Meshes.Ring)`
-- `quadgk(f, ::Meshes.Rope)`
-- `quadgk(f, ::Meshes.BezierCurve)`
 
 ## Example Usage
 
@@ -39,24 +49,27 @@ unit_circle = BezierCurve(
 fr(x,y,z) = abs(x + y)
 fr(p) = fr(p.coords...)
 
-@btime integral(fr, unit_circle)  # default n=100
+@btime lineintegral(fr, unit_circle)  # default n=100
     # 9.970 ms (18831 allocations: 78.40 MiB)
     # 5.55240987912083
 
-@btime integral(fr, unit_circle, n=10_000)
+@btime lineintegral(fr, unit_circle, n=10_000)
     # 16.932 ms (18835 allocations: 78.69 MiB)
     # 5.551055240210768
 
-@btime LineIntegrals.quadgk(fr, unit_circle)
+@btime quadgk_line(fr, unit_circle)
     # 9.871 ms (18829 allocations: 78.40 MiB)
     # (5.551055333711397, 1.609823385706477e-15)
 ```
 
-# Work in Progress
+# Plans and Work in Progress
 
-- Implement Aqua.jl tests
-- Register in General?
+- Register in General
     - Rename ideas: MeshesIntegrals? SpatialIntegrals?
-- Longer-term goals
-    - Surface integration of 2D features, e.g. `surfaceintegral(f, ::Triangle)`
-    - Volumetric integration of 3D features, e.g. `volumeintegral(f, ::Ball)`
+- Implement Aqua.jl tests
+- Implement Documenter docs
+- Implement methods
+    - `Meshes.Circle`: `surfaceintegral`, `quadgk_surface`
+    - `Meshes.Box{Dim,T}`: `surfaceintegral where {2,T}`, `volumeintegral where {>=3,T}`
+    - `Meshes.Ball`: `surfaceintegral`, `volumeintegral`
+    - `Meshes.Sphere`: `surfaceintegral`, `volumeintegral`

--- a/docs/surfaceintegral_triangle.md
+++ b/docs/surfaceintegral_triangle.md
@@ -1,0 +1,66 @@
+# Surface Integral Over a Triangle
+
+A linear transformation can be applied that maps any triangle onto a Barycentric
+coordinate system. A linear correction factor is then applied to correct for the
+domain transformation, where the area of the original triangle is $A$ and the area
+of the Barycentric triangle is $1/2$.
+```math
+\int_\triangle f(\bar{r}) \text{d}A
+    = \frac{A}{1/2} \int_0^1 \int_0^{1-v} f(u,v) \text{d}v \text{d}u
+```
+
+This Barycentric integral can be directly estimated using a nested application of
+the h-adaptive Gauss-Kronrod quadrature rules from QuadGK.jl (`quadgk_surface`).
+Alternatively, with some additional modification it can be transformed onto a
+fixed rectangular domain for integration via cubature rules or other nested
+quadrature rules.
+
+Let $g$ be a wrapper function for $f$ that is only non-zero at valid Barycentric
+coordinates.
+```math
+g(u,v,) =
+    \begin{cases}
+        f(u,v) & \text{if } 0 \le u+v \le 1 \\
+        0 & \text{otherwise}
+    \end{cases}
+```
+
+Then
+```math
+\int_0^1 \int_0^{1-v} f(u,v) \text{d}v \text{d}u
+    = \int_0^1 \int_0^1 g(u,v) \text{d}v \text{d}u
+```
+
+A domain transformation can be applied to map the Barycentric coordinate domains
+from $u,v \in [0,1]$ to $s,t \in [-1,1]$, enabling the application of Gauss-Legendre
+quadrature rules.
+```math
+s(u) = 2u - 1 \\
+u(s) = \frac{s+1}{2}
+\text{d}u = \frac{1}{2}\text{d}s
+```
+```math
+t(v) = 2v - 1 \\
+v(t) = \frac{t+1}{2}
+\text{d}v = \frac{1}{2}\text{d}t
+```
+
+Leading to
+```math
+\int_0^1 \int_0^1 g(u,v) \text{d}v \text{d}u
+    = \frac{1}{4} \int_{-1}^1 \int_{-1}^1 g(\frac{s+1}{2},\frac{t+1}{2}) \text{d}t \text{d}s
+```
+
+Gauss-Legendre nodes ($x \in [-1,1]$) and weights ($w$) for a rule of order $N$
+can be efficiently calculated using the FastGaussQuadrature.jl package.
+```math
+\int_{-1}^1 \int_{-1}^1 g(\frac{s+1}{2},\frac{t+1}{2}) \text{d}t \text{d}s
+    \approx \sum_{i=1}^N \sum_{j=1}_N w_i w_j f(x_i,x_j)
+```
+
+This approximation can be rolled back up the stack of equations, leading to an
+expression that numerically approximates the original integral problem as
+```math
+\int_\triangle f(\bar{r}) \text{d}A
+    = \frac{A}{4(1/2)} \sum_{i=1}^N \sum_{j=1}_N w_i w_j f(\frac{x_i+1}{2}, \frac{x_j+1}{2})
+```

--- a/src/LineIntegrals.jl
+++ b/src/LineIntegrals.jl
@@ -5,8 +5,8 @@ module LineIntegrals
     using QuadGK
 
     include("integrate.jl")
-    export integral
-    # non-exported API: quadgk
+    export lineintegral, surfaceintegral, volumeintegral
+    export quadgk_line, quadgk_surface
 
     include("utils.jl")
     export derivative, unitdirection

--- a/src/integrate.jl
+++ b/src/integrate.jl
@@ -308,13 +308,9 @@ function quadgk_surface(
     # Validate the provided integrand function
     _validate_integrand(f,Dim,T)
 
-    # Change of variables: u,v [-1,1] ↦ t [0,1]
-    t(x) = 0.5x + 0.5
-    point(u,v) = triangle(t(u), t(v))
-
     # Integrate the Barycentric triangle in (u,v)-space: (0,0), (0,1), (1,0)
     #   i.e. \int_{0}^{1} \int_{0}^{1-u} f(u,v) dv du
-    innerintegral(u) = QuadGK.quadgk(v -> f(point(u,v)), 0, 1-u; kwargs...)
+    innerintegral(u) = QuadGK.quadgk(v -> f(triangle(u,v)), 0, 1-u; kwargs...)
     outerintegral = QuadGK.quadgk(innerintegral, 0, 1; kwargs...)
 
     # Apply a linear domain-correction factor 0.5 ↦ area(triangle)

--- a/src/integrate.jl
+++ b/src/integrate.jl
@@ -148,19 +148,20 @@ function surfaceintegral(
     wws = Iterators.product(ws, ws)
     xxs = Iterators.product(xs, xs)
 
-    # Change of variables: x [-1,1] ↦ t [0,1]
-    t(x) = 0.5x + 0.5
-    point(x1,x2) = triangle(t(x1), t(x2))
+    # Domain transformation: u,v [-1,1] ↦ s,t [0,1]
+    s(u) = 0.5u + 0.5
+    t(v) = 0.5v + 0.5
+    point(xi,xj) = triangle(s(xi), t(xj))
 
     # Determine output type of f at a Point inside the triangle
     # Define an applicable zero value
     fzero = zero(f(point(-0.5,-0.5)))
 
     # Calculate weight-node product
-    function weightednode(((w1,w2), (x1,x2)))
-        if 0 < (t(x1) + t(x2)) < 1
+    function g(((wi,wj), (xi,xj)))
+        if 0 <= (s(x1) + t(x2)) <= 1
             # Valid coordinate (inside triangle)
-            return w1 * w2 * f(point(x1,x2))
+            return wi * wj * f(point(xi,xj))
         else
             # Invalid coordinate (outside triangle)
             return fzero
@@ -169,7 +170,7 @@ function surfaceintegral(
 
     # Calculate 2D Gauss-Legendre integral of f over Barycentric coordinates [-1,1]^2
     # Apply a linear domain-correction factor [-1,1]^2 ↦ area(triangle)
-    return 0.5 * abs(signarea(triangle)) .* sum(weightednode, zip(wws,xxs))
+    return 0.5 * abs(signarea(triangle)) .* sum(g, zip(wws,xxs))
 end
 
 

--- a/src/integrate.jl
+++ b/src/integrate.jl
@@ -304,7 +304,7 @@ function quadgk_surface(
     f,
     triangle::Meshes.Ngon{3,Dim,T};
     kwargs...
-)
+) where {Dim, T}
     # Validate the provided integrand function
     _validate_integrand(f,Dim,T)
 

--- a/src/integrate.jl
+++ b/src/integrate.jl
@@ -159,7 +159,7 @@ function surfaceintegral(
 
     # Calculate weight-node product
     function g(((wi,wj), (xi,xj)))
-        if 0 <= (s(x1) + t(x2)) <= 1
+        if 0 <= (s(xi) + t(xj)) <= 1
             # Valid coordinate (inside triangle)
             return wi * wj * f(point(xi,xj))
         else

--- a/src/integrate.jl
+++ b/src/integrate.jl
@@ -169,7 +169,7 @@ function surfaceintegral(
 
     # Calculate 2D Gauss-Legendre integral of f over Barycentric coordinates [-1,1]^2
     # Apply a linear domain-correction factor [-1,1]^2 ↦ area(triangle)
-    return 0.25 * abs(signarea(triangle)) .* sum(weightednode, zip(wws,xxs))
+    return 0.5 * abs(signarea(triangle)) .* sum(weightednode, zip(wws,xxs))
 end
 
 

--- a/src/integrate.jl
+++ b/src/integrate.jl
@@ -158,8 +158,9 @@ function surfaceintegral(
 
     # Calculate weight-node product
     function weightednode(((w1,w2), (x1,x2)))
-        if 0.0 <= (w1 + w2) <= 1.0
+        if 0 < (w1 + w2) < 1
             # Valid coordinate (inside triangle)
+            # (beware numerical error at exactly 0 or 1)
             return w1 * w2 * f(point(x1,x2))
         else
             # Invalid coordinate (outside triangle)

--- a/src/integrate.jl
+++ b/src/integrate.jl
@@ -290,7 +290,8 @@ end
 
 Numerically integrate a given function `f(::Point)` over the surface of a
 `geometry` using the h-adaptive Gauss-Kronrod quadrature rule from QuadGK.jl.
-All standard [`QuadGK.quadgk`](@ref) keyword arguments are supported.
+All standard [`QuadGK.quadgk`](@ref) keyword arguments are supported. Returns
+only the estimated integral value; unable to estimate error for a nested problem.
 """
 function quadgk_surface end
 
@@ -310,8 +311,8 @@ function quadgk_surface(
 
     # Integrate the Barycentric triangle in (u,v)-space: (0,0), (0,1), (1,0)
     #   i.e. \int_{0}^{1} \int_{0}^{1-u} f(u,v) dv du
-    innerintegral(u) = QuadGK.quadgk(v -> f(triangle(u,v)), 0, 1-u; kwargs...)
-    outerintegral = QuadGK.quadgk(innerintegral, 0, 1; kwargs...)
+    innerintegral(u) = QuadGK.quadgk(v -> f(triangle(u,v)), 0, 1-u; kwargs...)[1]
+    outerintegral = QuadGK.quadgk(innerintegral, 0, 1; kwargs...)[1]
 
     # Apply a linear domain-correction factor 0.5 ↦ area(triangle)
     return 2.0 * abs(signarea(triangle)) .* outerintegral

--- a/src/integrate.jl
+++ b/src/integrate.jl
@@ -1,18 +1,18 @@
-################################################################################
-#                              integral METHODS
-################################################################################
-
-# Validate that f has a method defined for f(::Point)
+# Validate that f has a method defined for f(::Point{Dim,T})
 @inline function _validate_integrand(f,Dim,T)
-    if !hasmethod(f, (Point{Dim,T},))
-        error("The provided Function f must have a method f(::Point{$Dim,$T})")
+    if hasmethod(f, (Point{Dim,T},))
+        return nothing
+    else
+        error("The provided Function f must have a method f(::Meshes.Point{$Dim,$T})")
     end
-
-    return nothing
 end
 
+################################################################################
+#                              lineintegral
+################################################################################
+
 """
-    integral(f, geometry; n=100)
+    lineintegral(f, geometry; n=100)
 
 Numerically integrate a given function `f(::Point)` along a 1D `geometry` using
 a Gauss-Legendre quadrature of order `n`.
@@ -22,10 +22,10 @@ method should yield results with 16-digit accuracy in O(n) time. If `f` is know
 to have some periodic content then `n` should (at a minimum) be greater than
 the expected number of periods, e.g. `length(geometry)/lambda`.
 """
-function integral end
+function lineintegral end
 
-# Integrate f(::Point{Dim,T}) over a Segment
-function integral(
+# Integrate f(::Point{Dim,T}) along a Segment{Dim,T}
+function lineintegral(
     f::F,
     segment::Meshes.Segment{Dim,T};
     n::Int64=100
@@ -45,23 +45,16 @@ function integral(
 end
 
 """
-    integral(f, curve; n=100, alg=Meshes.Horner())
+    lineintegral(f, curve::Meshes.BezierCurve; n=100, alg=Meshes.Horner())
 
-Numerically integrate a given function `f(::Point)` along a BezierCurve using
-a Gauss-Legendre quadrature of order `n`.
-
-So long as `f` can be well-approximated by a polynomial of order `2n-1`, this
-method should yield results with 16-digit accuracy in O(n) time. If `f` is know
-to have some periodic content then `n` should (at a minimum) be greater than
-the expected number of periods, e.g. `length(geometry)/lambda`.
-
+Like [`lineintegral`](@ref) but integrates along the domain defined a `curve`.
 By default this uses Horner's method to improve performance when parameterizing
 the `curve` at the expense of a small loss of precision. Additional accuracy
 can be obtained by specifying the use of DeCasteljau's algorithm instead with
 `alg=Meshes.DeCasteljau()` but can come at a steep cost in memory allocations,
 especially for curves with a large number of control points.
 """
-function integral(
+function lineintegral(
     f::F,
     curve::Meshes.BezierCurve{Dim,T,V};
     n::Int64=100,
@@ -81,8 +74,8 @@ function integral(
     return 0.5 * length(curve) * sum(w .* f(point(x)) for (w,x) in zip(ws, xs))
 end
 
-# Integrate f(::Point{Dim,T}) over a Rope (an open Chain)
-function integral(
+# Integrate f(::Point{Dim,T}) over a Rope{Dim,T} (an open Chain)
+function lineintegral(
     f::F,
     rope::Meshes.Rope{Dim,T};
     n::Int64=100
@@ -90,14 +83,11 @@ function integral(
     # Validate the provided integrand function
     _validate_integrand(f,Dim,T)
 
-    return sum(segment -> integral(f, segment; n=n), segments(rope))
+    return sum(segment -> lineintegral(f, segment; n=n), segments(rope))
 end
 
-# Integrate f(::Point{Dim,T}) over a Ring (a closed Chain)
-#   Allocations:
-#     segments(rope)
-#     integral(f, segment)
-function integral(
+# Integrate f(::Point{Dim,T}) over a Ring{Dim,T} (a closed Chain)
+function lineintegral(
     f::F,
     ring::Meshes.Ring{Dim,T};
     n::Int64=100
@@ -105,11 +95,11 @@ function integral(
     # Validate the provided integrand function
     _validate_integrand(f,Dim,T)
 
-    return sum(segment -> integral(f, segment; n=n), segments(ring))
+    return sum(segment -> lineintegral(f, segment; n=n), segments(ring))
 end
 
-# Integrate f(::Point{Dim,T}) over an arbitrary geometry construct
-function integral(
+# Integrate f(::Point{Dim,T}) over an arbitrary geometry in {Dim,T}
+function lineintegral(
     f::F,
     path::Vector{<:Meshes.Geometry{Dim,T}};
     n::Int64=100
@@ -117,21 +107,105 @@ function integral(
     # Validate the provided integrand function
     _validate_integrand(f,Dim,T)
 
-    return sum(section -> integral(f, section; n=n), path)
+    return sum(section -> lineintegral(f, section; n=n), path)
 end
 
 
 ################################################################################
-#                            quadgk Methods
+#                            surfaceintegral
 ################################################################################
 
 """
-    quadgk(f, segment::Segment; kws...)
+    surfaceintegral(f, geometry; n=100)
 
-Like [`QuadGK.quadgk`](@ref), but integrates along the domain of a Segment. All standard
-[`QuadGK.quadgk`](@ref) keyword arguments remain available.
+Numerically integrate a given function `f(::Point)` over a 2D surface `geometry`
+using a Gauss-Legendre quadrature of order `n`.
+
+So long as `f` can be well-approximated by a polynomial of order `2n-1`, this
+method should yield results with 16-digit accuracy in O(n) time. If `f` is know
+to have some periodic content then `n` should (at a minimum) be greater than
+the expected number of periods, e.g. `length(geometry)/lambda`.
 """
-function quadgk(
+function surfaceintegral end
+
+"""
+    surfaceintegral(f, triangle::Meshes.Triangle; n=100)
+
+Like [`surfaceintegral`](@ref) but integrates over the surface of a `triangle`
+using a Gauss-Legendre quadrature rule of order `n` along each Barycentric
+dimension of the triangle.
+"""
+function surfaceintegral(
+    f,
+    triangle::Meshes.Ngon{3,Dim,T};
+    n::Int64 = 100
+) where {Dim, T}
+    # Validate the provided integrand function
+    _validate_integrand(f,Dim,T)
+
+    # Get Gauss-Legendre nodes and weights for a 2D region [-1,1]^2
+    xs, ws = gausslegendre(n)
+    wws = Iterators.product(ws, ws)
+    xxs = Iterators.product(xs, xs)
+
+    # Change of variables: x [-1,1] ↦ t [0,1]
+    t(x) = 0.5x + 0.5
+    point(x1,x2) = triangle(t(x1), t(x2))
+
+    # Determine output type of f at a Point inside the triangle
+    # Define an applicable zero value
+    fzero = zero(f(point(-0.5,-0.5)))
+
+    # Calculate weight-node product
+    function weightednode((w1,w2), (x1,x2))
+        if 0.0 <= (w1 + w2) <= 1.0
+            # Valid coordinate (inside triangle)
+            return w1 * w2 * f(point(x1,x2))
+        else
+            # Invalid coordinate (outside triangle)
+            return fzero
+        end
+    end
+
+    # Calculate 2D Gauss-Legendre integral of f over Barycentric coordinates [-1,1]^2
+    # Apply a linear domain-correction factor [-1,1]^2 ↦ area(triangle)
+    return 0.25 * abs(signarea(triangle)) .* sum(weightednode, zip(weights,nodes))
+end
+
+
+################################################################################
+#                             volumeintegral
+################################################################################
+
+"""
+    volumeintegral(f, geometry; n=100)
+
+Numerically integrate a given function `f(::Point)` throughout a volumetric
+`geometry` using a Gauss-Legendre quadrature of order `n`.
+
+So long as `f` can be well-approximated by a polynomial of order `2n-1`, this
+method should yield results with 16-digit accuracy in O(n) time. If `f` is know
+to have some periodic content then `n` should (at a minimum) be greater than
+the expected number of periods, e.g. `length(geometry)/lambda`.
+"""
+function volumeintegral end
+
+
+################################################################################
+#                                quadgk_line
+################################################################################
+
+"""
+    quadgk_line(f, geometry; kws...)
+
+Numerically integrate a given function `f(::Point)` along a 1D `geometry` using
+the h-adaptive Gauss-Kronrod quadrature rule from QuadGK.jl. All standard
+[`QuadGK.quadgk`](@ref) keyword arguments are supported.
+"""
+function quadgk_line end
+
+# Integrate f(::Point{Dim,T}) along a Segment{Dim,T}
+function quadgk_line(
     f::F,
     segment::Meshes.Segment{Dim,T};
     kwargs...
@@ -145,18 +219,16 @@ function quadgk(
 end
 
 """
-    quadgk(f, curve::BezierCurve; alg=Horner(), kws...)
+    quadgk_line(f, curve::BezierCurve; alg=Horner(), kws...)
 
-Like [`QuadGK.quadgk`](@ref), but integrates along the domain of a Bezier curve. All
-standard [`QuadGK.quadgk`](@ref) keyword arguments remain available.
-
+Like [`quadgk_line`](@ref) but integrates along the domain defined a `curve`.
 By default this uses Horner's method to improve performance when parameterizing
 the `curve` at the expense of a small loss of precision. Additional accuracy
 can be obtained by specifying the use of DeCasteljau's algorithm instead with
 `alg=Meshes.DeCasteljau()` but can come at a steep cost in memory allocations,
 especially for curves with a large number of control points.
 """
-function quadgk(
+function quadgk_line(
     f::F,
     curve::Meshes.BezierCurve{Dim,T,V};
     alg::Meshes.BezierEvalMethod=Meshes.Horner(),
@@ -170,60 +242,81 @@ function quadgk(
     return QuadGK.quadgk(t -> len * f(point(t)), 0, 1; kwargs...)
 end
 
-"""
-    quadgk(f, points::Point...; kws...)
-
-Like [`QuadGK.quadgk`](@ref), but integrates along a domain befined by the linear
-segments formed between a series of Points. All standard [`QuadGK.quadgk`](@ref)
-keyword arguments remain available.
-"""
-function quadgk(
-    f,
-    pts::Meshes.Point{Dim,T}...;
-    kwargs...
-) where {Dim, T}
-    # Validate the provided integrand function
-    _validate_integrand(f,Dim,T)
-
-    # Collect Points into a Rope, integrate that
-    rope = Meshes.Rope(pts...)
-    return quadgk(f, rope; kwargs...)
-end
-
-"""
-    quadgk(f, ring::Ring; kws...)
-
-Like [`QuadGK.quadgk`](@ref), but integrates along the domain of a Ring. All standard
-[`QuadGK.quadgk`](@ref) keyword arguments remain available.
-"""
-function quadgk(
+# Integrate f(::Point{Dim,T}) over a Ring{Dim,T} (a closed Chain)
+function quadgk_line(
     f::F,
     ring::Meshes.Ring{Dim,T};
     kwargs...
 ) where {F<:Function, Dim, T}
-    # Validate the provided integrand function
-    _validate_integrand(f,Dim,T)
-
     # Partition the Ring into Segments, integrate each, sum results
-    chunks = map(segment -> quadgk(f, segment; kwargs...), segments(ring))
+    chunks = map(segment -> quadgk_line(f, segment; kwargs...), segments(ring))
     return reduce(.+, chunks)
 end
 
-"""
-    quadgk(f, rope::Rope; kws...)
-
-Like [`QuadGK.quadgk`](@ref), but integrates along the domain of a Rope. All standard
-[`QuadGK.quadgk`](@ref) keyword arguments remain available.
-"""
-function quadgk(
+# Integrate f(::Point{Dim,T}) over a Rope{Dim,T} (an open Chain)
+function quadgk_line(
     f::F,
     rope::Meshes.Rope{Dim,T};
     kwargs...
 ) where {F<:Function, Dim, T}
+    # Partition the Rope into Segments, integrate each, sum results
+    chunks = map(segment -> quadgk_line(f, segment; kwargs...), segments(rope))
+    return reduce(.+, chunks)
+end
+
+"""
+    quadgk_line(f, points::Point...; kws...)
+
+Like [`quadgk_line`](@ref), but integrates along a domain befined by the linear
+segments formed between a series of Points.
+"""
+function quadgk_line(
+    f,
+    pts::Meshes.Point{Dim,T}...;
+    kwargs...
+) where {Dim, T}
+    # Collect Points into a Rope, integrate that
+    rope = Meshes.Rope(pts...)
+    return quadgk_line(f, rope; kwargs...)
+end
+
+
+################################################################################
+#                                quadgk_surface
+################################################################################
+
+"""
+    quadgk_surface(f, geometry; kws...)
+
+Numerically integrate a given function `f(::Point)` over the surface of a
+`geometry` using the h-adaptive Gauss-Kronrod quadrature rule from QuadGK.jl.
+All standard [`QuadGK.quadgk`](@ref) keyword arguments are supported.
+"""
+function quadgk_surface end
+
+"""
+    quadgk_surface(f, triangle::Meshes.Triangle; kws...)
+
+Like [`quadgk_surface`](@ref), but integrates `f` over the surface of a `triangle`
+using a nested integration in the Barycentric coordinate domain.
+"""
+function quadgk_surface(
+    f,
+    triangle::Meshes.Ngon{3,Dim,T};
+    kwargs...
+)
     # Validate the provided integrand function
     _validate_integrand(f,Dim,T)
 
-    # Partition the Rope into Segments, integrate each, sum results
-    chunks = map(segment -> quadgk(f, segment; kwargs...), segments(rope))
-    return reduce(.+, chunks)
+    # Change of variables: u,v [-1,1] ↦ t [0,1]
+    t(x) = 0.5x + 0.5
+    point(u,v) = triangle(t(u), t(v))
+
+    # Integrate the Barycentric triangle in (u,v)-space: (0,0), (0,1), (1,0)
+    #   i.e. \int_{0}^{1} \int_{0}^{1-u} f(u,v) dv du
+    innerintegral(u) = QuadGK.quadgk(v -> f(point(u,v)), 0, 1-u; kwargs...)
+    outerintegral = QuadGK.quadgk(innerintegral, 0, 1; kwargs...)
+
+    # Apply a linear domain-correction factor 0.5 ↦ area(triangle)
+    return 2.0 * abs(signarea(triangle)) .* outerintegral
 end

--- a/src/integrate.jl
+++ b/src/integrate.jl
@@ -169,7 +169,7 @@ function surfaceintegral(
 
     # Calculate 2D Gauss-Legendre integral of f over Barycentric coordinates [-1,1]^2
     # Apply a linear domain-correction factor [-1,1]^2 ↦ area(triangle)
-    return 0.25 * abs(signarea(triangle)) .* sum(weightednode, zip(weights,nodes))
+    return 0.25 * abs(signarea(triangle)) .* sum(weightednode, zip(wws,xxs))
 end
 
 

--- a/src/integrate.jl
+++ b/src/integrate.jl
@@ -157,7 +157,7 @@ function surfaceintegral(
     fzero = zero(f(point(-0.5,-0.5)))
 
     # Calculate weight-node product
-    function weightednode((w1,w2), (x1,x2))
+    function weightednode(((w1,w2), (x1,x2)))
         if 0.0 <= (w1 + w2) <= 1.0
             # Valid coordinate (inside triangle)
             return w1 * w2 * f(point(x1,x2))

--- a/src/integrate.jl
+++ b/src/integrate.jl
@@ -170,7 +170,7 @@ function surfaceintegral(
 
     # Calculate 2D Gauss-Legendre integral of f over Barycentric coordinates [-1,1]^2
     # Apply a linear domain-correction factor [-1,1]^2 ↦ area(triangle)
-    return 0.5 * abs(signarea(triangle)) .* sum(g, zip(wws,xxs))
+    return 0.5 * area(triangle) .* sum(g, zip(wws,xxs))
 end
 
 
@@ -316,5 +316,5 @@ function quadgk_surface(
     outerintegral = QuadGK.quadgk(innerintegral, 0, 1; kwargs...)[1]
 
     # Apply a linear domain-correction factor 0.5 ↦ area(triangle)
-    return 2.0 * abs(signarea(triangle)) .* outerintegral
+    return 2.0 * area(triangle) .* outerintegral
 end

--- a/src/integrate.jl
+++ b/src/integrate.jl
@@ -159,7 +159,7 @@ function surfaceintegral(
 
     # Calculate weight-node product
     function g(((wi,wj), (xi,xj)))
-        if 0 <= (s(xi) + t(xj)) <= 1
+        if 0 < (s(xi) + t(xj)) < 1
             # Valid coordinate (inside triangle)
             return wi * wj * f(point(xi,xj))
         else

--- a/src/integrate.jl
+++ b/src/integrate.jl
@@ -158,9 +158,8 @@ function surfaceintegral(
 
     # Calculate weight-node product
     function weightednode(((w1,w2), (x1,x2)))
-        if 0 < (w1 + w2) < 1
+        if 0 < (t(x1) + t(x2)) < 1
             # Valid coordinate (inside triangle)
-            # (beware numerical error at exactly 0 or 1)
             return w1 * w2 * f(point(x1,x2))
         else
             # Invalid coordinate (outside triangle)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -45,3 +45,18 @@ function unitdirection(bz::Meshes.BezierCurve{Dim,T,V}, t) where {Dim,T,V}
     LinearAlgebra.normalize!(u)
     return u    # ::Vec{Dim,T}
 end
+
+"""
+    area(triangle::Meshes.Triangle)
+
+Calculate the un-signed area of a `triangle`.
+"""
+function area(triangle::Meshes.Ngon{3,Dim,T}) where {Dim, T}
+    # Use Heron's formula
+    A, B, C = triangle.vertices
+    a = norm(B-A)
+    b = norm(C-B)
+    c = norm(A-C)
+    s = (a + b + c) / 2
+    return sqrt( s * (s-a) * (s-b) * (s-c) )
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ using Test
 #                             Tests -- Integrals
 ################################################################################
 
-@testset "Integrate" beginDim
+@testset "Integrate" begin
     # Points on unit circle at axes
     pt_e = Point( 1.0,  0.0, 0.0)
     pt_n = Point( 0.0,  1.0, 0.0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,7 +62,7 @@ using Test
         @test lineintegral(f, rect_traj_ring) ≈ 4sqrt(2)                # Meshes.Ring
         @test lineintegral(f, rect_traj_rope) ≈ 4sqrt(2)                # Meshes.Rope
         @test isapprox(lineintegral(f, unit_circle), 2pi; atol=0.15)    # Meshes.BezierCurve
-        @test isapprox(surfaceintegral(f, triangle), 1.0; atol=1e-3)    # Meshes.Triangle
+        @test isapprox(surfaceintegral(f, triangle; n=1000), 1.0; atol=0.01)    # Meshes.Triangle
     end
 
     @testset "Vector-Valued Functions" begin
@@ -72,7 +72,7 @@ using Test
         @test lineintegral(f, rect_traj_ring) ≈ 4 .* [sqrt(2), sqrt(2), sqrt(2)]   # Meshes.Ring
         @test lineintegral(f, rect_traj_rope) ≈ 4 .* [sqrt(2), sqrt(2), sqrt(2)]   # Meshes.Rope
         @test isapprox(lineintegral(f, unit_circle), [2π, 2π, 2π]; atol=0.15)      # Meshes.BezierCurve
-        @test isapprox(surfaceintegral(f, triangle), [1.0, 1.0, 1.0]; atol=1e-3)   # Meshes.Triangle
+        @test isapprox(surfaceintegral(f, triangle; n=1000), [1.0, 1.0, 1.0]; atol=0.01)   # Meshes.Triangle
     end
 
     @testset "Results Consistent with QuadGK" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,16 +33,19 @@ using Test
     )
 
     # Triangle on upper-half-plane
-    triangle = Ngon(pt_e, pt_n, pt_w)
+    triangle3d = Ngon(pt_e, pt_n, pt_w)
+    # TODO debug: Point{3,T} seems to explode on signarea(triangle3d)
+    triangle2d = Ngon(Point(1.0,0.0), Point(0.0,1.0), Point(-1.0,0.0))
 
     @testset "quadgk_line Methods" begin
         f(::Point{Dim,T}) where {Dim,T} = 1.0
-        @test quadgk_line(f, seg_ne)[1] ≈ sqrt(2)                        # Meshes.Segment
-        @test quadgk_line(f, rect_traj_ring)[1] ≈ 4sqrt(2)               # Meshes.Ring
-        @test quadgk_line(f, rect_traj_rope)[1] ≈ 4sqrt(2)               # Meshes.Rope
-        @test isapprox(quadgk_line(f, unit_circle)[1], 2pi; atol=0.15)   # Meshes.BezierCurve
-        @test quadgk_line(f, pt_e, pt_n, pt_w, pt_s, pt_e)[1] ≈ 4sqrt(2)    # Varargs of Meshes.Point
-        @test quadgk_surface(f, triangle) ≈ 1.0                          # Meshes.Triangle
+        @test quadgk_line(f, seg_ne)[1] ≈ sqrt(2)                         # Meshes.Segment
+        @test quadgk_line(f, rect_traj_ring)[1] ≈ 4sqrt(2)                # Meshes.Ring
+        @test quadgk_line(f, rect_traj_rope)[1] ≈ 4sqrt(2)                # Meshes.Rope
+        @test isapprox(quadgk_line(f, unit_circle)[1], 2pi; atol=0.15)    # Meshes.BezierCurve
+        @test quadgk_line(f, pt_e, pt_n, pt_w, pt_s, pt_e)[1] ≈ 4sqrt(2)  # Varargs of Meshes.Point
+        @test quadgk_surface(f, triangle2d) ≈ 1.0                         # Meshes.Triangle
+        @test quadgk_surface(f, triangle3d) ≈ 1.0                         # Meshes.Triangle
     end
 
     @testset "Caught Errors" begin
@@ -62,7 +65,8 @@ using Test
         @test lineintegral(f, rect_traj_ring) ≈ 4sqrt(2)                # Meshes.Ring
         @test lineintegral(f, rect_traj_rope) ≈ 4sqrt(2)                # Meshes.Rope
         @test isapprox(lineintegral(f, unit_circle), 2pi; atol=0.15)    # Meshes.BezierCurve
-        @test isapprox(surfaceintegral(f, triangle), 1.0; atol=1e-3)    # Meshes.Triangle
+        @test isapprox(surfaceintegral(f, triangle2d), 1.0; atol=1e-3)  # Meshes.Triangle
+        @test isapprox(surfaceintegral(f, triangle3d), 1.0; atol=1e-3)  # Meshes.Triangle
     end
 
     @testset "Vector-Valued Functions" begin
@@ -72,7 +76,8 @@ using Test
         @test lineintegral(f, rect_traj_ring) ≈ 4 .* [sqrt(2), sqrt(2), sqrt(2)]   # Meshes.Ring
         @test lineintegral(f, rect_traj_rope) ≈ 4 .* [sqrt(2), sqrt(2), sqrt(2)]   # Meshes.Rope
         @test isapprox(lineintegral(f, unit_circle), [2π, 2π, 2π]; atol=0.15)      # Meshes.BezierCurve
-        @test isapprox(surfaceintegral(f, triangle), [1.0, 1.0, 1.0]; atol=1e-3)   # Meshes.Triangle
+        @test isapprox(surfaceintegral(f, triangle2d), [1.0, 1.0, 1.0]; atol=1e-3) # Meshes.Triangle
+        @test isapprox(surfaceintegral(f, triangle3d), [1.0, 1.0, 1.0]; atol=1e-3) # Meshes.Triangle
     end
 
     @testset "Results Consistent with QuadGK" begin
@@ -101,6 +106,8 @@ end
 ################################################################################
 #                             Tests -- Unitful.jl
 ################################################################################
+
+# TODO implement triangle surfaceintegral tests
 
 @testset "Integrate with Unitful.jl" begin
     m = Unitful.m

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,7 @@ using Test
         @test quadgk_line(f, rect_traj_rope)[1] ≈ 4sqrt(2)               # Meshes.Rope
         @test isapprox(quadgk_line(f, unit_circle)[1], 2pi; atol=0.15)   # Meshes.BezierCurve
         @test quadgk_line(f, pt_e, pt_n, pt_w, pt_s, pt_e)[1] ≈ 4sqrt(2)    # Varargs of Meshes.Point
+        @test quadgk_surface(f, triangle) ≈ 1.0                          # Meshes.Triangle
     end
 
     @testset "Caught Errors" begin
@@ -61,7 +62,7 @@ using Test
         @test lineintegral(f, rect_traj_ring) ≈ 4sqrt(2)                # Meshes.Ring
         @test lineintegral(f, rect_traj_rope) ≈ 4sqrt(2)                # Meshes.Rope
         @test isapprox(lineintegral(f, unit_circle), 2pi; atol=0.15)    # Meshes.BezierCurve
-        @test surfaceintegral(f, triangle) ≈ 1.0                        # Meshes.Triangle
+        @test isapprox(surfaceintegral(f, triangle), 1.0; atol=1e-3)    # Meshes.Triangle
     end
 
     @testset "Vector-Valued Functions" begin
@@ -71,7 +72,7 @@ using Test
         @test lineintegral(f, rect_traj_ring) ≈ 4 .* [sqrt(2), sqrt(2), sqrt(2)]   # Meshes.Ring
         @test lineintegral(f, rect_traj_rope) ≈ 4 .* [sqrt(2), sqrt(2), sqrt(2)]   # Meshes.Rope
         @test isapprox(lineintegral(f, unit_circle), [2π, 2π, 2π]; atol=0.15)      # Meshes.BezierCurve
-        @test surfaceintegral(f, triangle) ≈ [1.0, 1.0, 1.0]                       # Meshes.Triangle
+        @test isapprox(surfaceintegral(f, triangle), [1.0, 1.0, 1.0]; atol=1e-3)   # Meshes.Triangle
     end
 
     @testset "Results Consistent with QuadGK" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ using Test
 #                             Tests -- Integrals
 ################################################################################
 
-@testset "Integrate" begin
+@testset "Integrate" beginDim
     # Points on unit circle at axes
     pt_e = Point( 1.0,  0.0, 0.0)
     pt_n = Point( 0.0,  1.0, 0.0)
@@ -32,52 +32,48 @@ using Test
         [Point(cos(t), sin(t), 0.0) for t in range(0, 2pi, length=361)]
     )
 
-    @testset "QuadGK Methods" begin
+    @testset "quadgk_line Methods" begin
         f(::Point{Dim,T}) where {Dim,T} = 1.0
-        @test LineIntegrals.quadgk(f, seg_ne)[1] ≈ sqrt(2)                        # Meshes.Segment
-        @test LineIntegrals.quadgk(f, rect_traj_ring)[1] ≈ 4sqrt(2)               # Meshes.Ring
-        @test LineIntegrals.quadgk(f, rect_traj_rope)[1] ≈ 4sqrt(2)               # Meshes.Rope
-        @test isapprox(LineIntegrals.quadgk(f, unit_circle)[1], 2pi; atol=0.15)   # Meshes.BezierCurve
-        @test LineIntegrals.quadgk(f, pt_e, pt_n, pt_w, pt_s, pt_e)[1] ≈ 4sqrt(2)    # Varargs of Meshes.Point
-
-        # This test is useful if these quadgk methods are exported as QuadGK.quadgk methods
-        #   to ensure they don't clash with non-Meshes methods.
-        # @test quadgk(t -> exp(-t), 0, 10, 100)[1] ≈ 1    # Verify compatibility with generic Vararg{T} method
+        @test quadgk_line(f, seg_ne)[1] ≈ sqrt(2)                        # Meshes.Segment
+        @test quadgk_line(f, rect_traj_ring)[1] ≈ 4sqrt(2)               # Meshes.Ring
+        @test quadgk_line(f, rect_traj_rope)[1] ≈ 4sqrt(2)               # Meshes.Rope
+        @test isapprox(quadgk_line(f, unit_circle)[1], 2pi; atol=0.15)   # Meshes.BezierCurve
+        @test quadgk_line(f, pt_e, pt_n, pt_w, pt_s, pt_e)[1] ≈ 4sqrt(2)    # Varargs of Meshes.Point
     end
 
     @testset "Caught Errors" begin
         # Catch wrong method signature: f(x,y,z) vs f(::Point)
         fvec(x,y,z) = x*y*z
-        @test_throws ErrorException integral(fvec, seg_ne)          # Meshes.Segment
-        @test_throws ErrorException integral(fvec, rect_traj_segs)  # Vector{::Meshes.Segment}
-        @test_throws ErrorException integral(fvec, rect_traj_ring)  # Meshes.Ring
-        @test_throws ErrorException integral(fvec, rect_traj_rope)  # Meshes.Rope
-        @test_throws ErrorException integral(fvec, unit_circle)     # Meshes.BezierCurve
+        @test_throws ErrorException lineintegral(fvec, seg_ne)          # Meshes.Segment
+        @test_throws ErrorException lineintegral(fvec, rect_traj_segs)  # Vector{::Meshes.Segment}
+        @test_throws ErrorException lineintegral(fvec, rect_traj_ring)  # Meshes.Ring
+        @test_throws ErrorException lineintegral(fvec, rect_traj_rope)  # Meshes.Rope
+        @test_throws ErrorException lineintegral(fvec, unit_circle)     # Meshes.BezierCurve
     end
 
     @testset "Scalar-Valued Functions" begin
         f(::Point{Dim,T}) where {Dim,T} = 1.0
-        @test integral(f, seg_ne) ≈ sqrt(2)                         # Meshes.Segment
-        @test integral(f, rect_traj_segs) ≈ 4sqrt(2)                # Vector{::Meshes.Segment}
-        @test integral(f, rect_traj_ring) ≈ 4sqrt(2)                # Meshes.Ring
-        @test integral(f, rect_traj_rope) ≈ 4sqrt(2)                # Meshes.Rope
-        @test isapprox(integral(f, unit_circle), 2pi; atol=0.15)    # Meshes.BezierCurve
+        @test lineintegral(f, seg_ne) ≈ sqrt(2)                         # Meshes.Segment
+        @test lineintegral(f, rect_traj_segs) ≈ 4sqrt(2)                # Vector{::Meshes.Segment}
+        @test lineintegral(f, rect_traj_ring) ≈ 4sqrt(2)                # Meshes.Ring
+        @test lineintegral(f, rect_traj_rope) ≈ 4sqrt(2)                # Meshes.Rope
+        @test isapprox(lineintegral(f, unit_circle), 2pi; atol=0.15)    # Meshes.BezierCurve
     end
 
     @testset "Vector-Valued Functions" begin
         f(::Point{Dim,T}) where {Dim,T} = [1.0, 1.0, 1.0]
-        @test integral(f, seg_ne) ≈ [sqrt(2), sqrt(2), sqrt(2)]                # Meshes.Segment
-        @test integral(f, rect_traj_segs) ≈ 4 .* [sqrt(2), sqrt(2), sqrt(2)]   # Vector{::Meshes.Segment}
-        @test integral(f, rect_traj_ring) ≈ 4 .* [sqrt(2), sqrt(2), sqrt(2)]   # Meshes.Ring
-        @test integral(f, rect_traj_rope) ≈ 4 .* [sqrt(2), sqrt(2), sqrt(2)]   # Meshes.Rope
-        @test isapprox(integral(f, unit_circle), [2π, 2π, 2π]; atol=0.15)      # Meshes.BezierCurve
+        @test lineintegral(f, seg_ne) ≈ [sqrt(2), sqrt(2), sqrt(2)]                # Meshes.Segment
+        @test lineintegral(f, rect_traj_segs) ≈ 4 .* [sqrt(2), sqrt(2), sqrt(2)]   # Vector{::Meshes.Segment}
+        @test lineintegral(f, rect_traj_ring) ≈ 4 .* [sqrt(2), sqrt(2), sqrt(2)]   # Meshes.Ring
+        @test lineintegral(f, rect_traj_rope) ≈ 4 .* [sqrt(2), sqrt(2), sqrt(2)]   # Meshes.Rope
+        @test isapprox(lineintegral(f, unit_circle), [2π, 2π, 2π]; atol=0.15)      # Meshes.BezierCurve
     end
 
     @testset "Results Consistent with QuadGK" begin
         # Test handling of real-valued functions
         fr(x) = exp(-x)
         fr(p::Point) = fr(p.coords[1])
-        @test LineIntegrals.quadgk(fr, Point(0,0), Point(100,0))[1] ≈ QuadGK.quadgk(fr, 0, 100)[1]
+        @test quadgk_line(fr, Point(0,0), Point(100,0))[1] ≈ QuadGK.quadgk(fr, 0, 100)[1]
     end
 
     @testset "Contour Integrals on a Point{1,Complex}-Domain" begin
@@ -92,7 +88,7 @@ using Test
         # 2πi Res_{z=0}(1/z) = \int_C (1/z) dz
         # Res_{z=0}(1/z) = 1
         # ∴ \int_C (1/z) dz = 2πi
-        @test integral(fc, unit_circle_complex, n=1000) ≈ 2π*im
+        @test lineintegral(fc, unit_circle_complex, n=1000) ≈ 2π*im
     end
 end
 
@@ -128,20 +124,20 @@ end
 
     @testset "Scalar-Valued Functions" begin
         f(::Point{Dim,T}) where {Dim,T} = 1.0Ω/m
-        @test integral(f, seg_ne) ≈ sqrt(2)*Ω                         # Meshes.Segment
-        @test integral(f, rect_traj_segs) ≈ 4sqrt(2)*Ω                # Vector{::Meshes.Segment}
-        @test integral(f, rect_traj_ring) ≈ 4sqrt(2)*Ω                # Meshes.Ring
-        @test integral(f, rect_traj_rope) ≈ 4sqrt(2)*Ω                # Meshes.Rope
-        @test isapprox(integral(f, unit_circle), 2π*Ω; atol=0.15Ω)    # Meshes.BezierCurve
+        @test lineintegral(f, seg_ne) ≈ sqrt(2)*Ω                         # Meshes.Segment
+        @test lineintegral(f, rect_traj_segs) ≈ 4sqrt(2)*Ω                # Vector{::Meshes.Segment}
+        @test lineintegral(f, rect_traj_ring) ≈ 4sqrt(2)*Ω                # Meshes.Ring
+        @test lineintegral(f, rect_traj_rope) ≈ 4sqrt(2)*Ω                # Meshes.Rope
+        @test isapprox(lineintegral(f, unit_circle), 2π*Ω; atol=0.15Ω)    # Meshes.BezierCurve
     end
 
     @testset "Vector-Valued Functions" begin
         f(::Point{Dim,T}) where {Dim,T} = [1.0Ω/m, 1.0Ω/m, 1.0Ω/m]
-        @test integral(f, seg_ne) ≈ [sqrt(2), sqrt(2), sqrt(2)] .* Ω                  # Meshes.Segment
-        @test integral(f, rect_traj_segs)  ≈ 4 .* [sqrt(2), sqrt(2), sqrt(2)] .* Ω    # Vector{::Meshes.Segment}
-        @test integral(f, rect_traj_ring) ≈ 4 .* [sqrt(2), sqrt(2), sqrt(2)] .* Ω     # Meshes.Ring
-        @test integral(f, rect_traj_rope) ≈ 4 .* [sqrt(2), sqrt(2), sqrt(2)] .* Ω     # Meshes.Rope
-        @test isapprox(integral(f, unit_circle), [2π, 2π, 2π] .* Ω; atol=0.15Ω)    # Meshes.BezierCurve
+        @test lineintegral(f, seg_ne) ≈ [sqrt(2), sqrt(2), sqrt(2)] .* Ω                  # Meshes.Segment
+        @test lineintegral(f, rect_traj_segs)  ≈ 4 .* [sqrt(2), sqrt(2), sqrt(2)] .* Ω    # Vector{::Meshes.Segment}
+        @test lineintegral(f, rect_traj_ring) ≈ 4 .* [sqrt(2), sqrt(2), sqrt(2)] .* Ω     # Meshes.Ring
+        @test lineintegral(f, rect_traj_rope) ≈ 4 .* [sqrt(2), sqrt(2), sqrt(2)] .* Ω     # Meshes.Rope
+        @test isapprox(lineintegral(f, unit_circle), [2π, 2π, 2π] .* Ω; atol=0.15Ω)    # Meshes.BezierCurve
     end
 end
 
@@ -182,21 +178,21 @@ end
 
     @testset "Scalar-Valued Functions" begin
         f(::Point{Dim,T}) where {Dim,T} = 1.0Ω/m
-        @test integral(f, seg_ne) ≈ sqrt(2)*Ω                         # Meshes.Segment
-        @test integral(f, rect_traj_segs) ≈ 4sqrt(2)*Ω                # Vector{::Meshes.Segment}
-        @test integral(f, rect_traj_ring) ≈ 4sqrt(2)*Ω                # Meshes.Ring
-        @test integral(f, rect_traj_rope) ≈ 4sqrt(2)*Ω                # Meshes.Rope
-        @test isapprox(integral(f, unit_circle), 2π*Ω; atol=0.15)    # Meshes.BezierCurve
+        @test lineintegral(f, seg_ne) ≈ sqrt(2)*Ω                         # Meshes.Segment
+        @test lineintegral(f, rect_traj_segs) ≈ 4sqrt(2)*Ω                # Vector{::Meshes.Segment}
+        @test lineintegral(f, rect_traj_ring) ≈ 4sqrt(2)*Ω                # Meshes.Ring
+        @test lineintegral(f, rect_traj_rope) ≈ 4sqrt(2)*Ω                # Meshes.Rope
+        @test isapprox(lineintegral(f, unit_circle), 2π*Ω; atol=0.15)    # Meshes.BezierCurve
               # TODO change 0.15 => 0.15Ω once DynamicQuantities PR approved
     end
 
     @testset "Vector-Valued Functions" begin
         f(::Point{Dim,T}) where {Dim,T} = [1.0Ω/m, 1.0Ω/m, 1.0Ω/m]
-        @test all(isapprox.(integral(f, seg_ne), sqrt(2)*Ω))                # Meshes.Segment
-        @test all(isapprox.(integral(f, rect_traj_segs), 4sqrt(2)*Ω))       # Vector{::Meshes.Segment}
-        @test all(isapprox.(integral(f, rect_traj_ring), 4sqrt(2)*Ω))       # Meshes.Ring
-        @test all(isapprox.(integral(f, rect_traj_rope), 4sqrt(2)*Ω))       # Meshes.Rope
-        @test all(isapprox.(integral(f, unit_circle), 2π*Ω; atol=0.15))    # Meshes.BezierCurve
+        @test all(isapprox.(lineintegral(f, seg_ne), sqrt(2)*Ω))                # Meshes.Segment
+        @test all(isapprox.(lineintegral(f, rect_traj_segs), 4sqrt(2)*Ω))       # Vector{::Meshes.Segment}
+        @test all(isapprox.(lineintegral(f, rect_traj_ring), 4sqrt(2)*Ω))       # Meshes.Ring
+        @test all(isapprox.(lineintegral(f, rect_traj_rope), 4sqrt(2)*Ω))       # Meshes.Rope
+        @test all(isapprox.(lineintegral(f, unit_circle), 2π*Ω; atol=0.15))    # Meshes.BezierCurve
              # TODO change 0.15 => 0.15Ω once DynamicQuantities PR approved
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,9 @@ using Test
         [Point(cos(t), sin(t), 0.0) for t in range(0, 2pi, length=361)]
     )
 
+    # Triangle on upper-half-plane
+    triangle = Ngon(pt_e, pt_n, pt_w)
+
     @testset "quadgk_line Methods" begin
         f(::Point{Dim,T}) where {Dim,T} = 1.0
         @test quadgk_line(f, seg_ne)[1] ≈ sqrt(2)                        # Meshes.Segment
@@ -58,6 +61,7 @@ using Test
         @test lineintegral(f, rect_traj_ring) ≈ 4sqrt(2)                # Meshes.Ring
         @test lineintegral(f, rect_traj_rope) ≈ 4sqrt(2)                # Meshes.Rope
         @test isapprox(lineintegral(f, unit_circle), 2pi; atol=0.15)    # Meshes.BezierCurve
+        @test surfaceintegral(f, triangle) ≈ 1.0                        # Meshes.Triangle
     end
 
     @testset "Vector-Valued Functions" begin
@@ -67,6 +71,7 @@ using Test
         @test lineintegral(f, rect_traj_ring) ≈ 4 .* [sqrt(2), sqrt(2), sqrt(2)]   # Meshes.Ring
         @test lineintegral(f, rect_traj_rope) ≈ 4 .* [sqrt(2), sqrt(2), sqrt(2)]   # Meshes.Rope
         @test isapprox(lineintegral(f, unit_circle), [2π, 2π, 2π]; atol=0.15)      # Meshes.BezierCurve
+        @test surfaceintegral(f, triangle) ≈ [1.0, 1.0, 1.0]                       # Meshes.Triangle
     end
 
     @testset "Results Consistent with QuadGK" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,9 +33,7 @@ using Test
     )
 
     # Triangle on upper-half-plane
-    triangle3d = Ngon(pt_e, pt_n, pt_w)
-    # TODO debug: Point{3,T} seems to explode on signarea(triangle3d)
-    triangle2d = Ngon(Point(1.0,0.0), Point(0.0,1.0), Point(-1.0,0.0))
+    triangle = Ngon(pt_e, pt_n, pt_w)
 
     @testset "quadgk_line Methods" begin
         f(::Point{Dim,T}) where {Dim,T} = 1.0
@@ -44,8 +42,7 @@ using Test
         @test quadgk_line(f, rect_traj_rope)[1] ≈ 4sqrt(2)                # Meshes.Rope
         @test isapprox(quadgk_line(f, unit_circle)[1], 2pi; atol=0.15)    # Meshes.BezierCurve
         @test quadgk_line(f, pt_e, pt_n, pt_w, pt_s, pt_e)[1] ≈ 4sqrt(2)  # Varargs of Meshes.Point
-        @test quadgk_surface(f, triangle2d) ≈ 1.0                         # Meshes.Triangle
-        @test quadgk_surface(f, triangle3d) ≈ 1.0                         # Meshes.Triangle
+        @test quadgk_surface(f, triangle) ≈ 1.0                           # Meshes.Triangle
     end
 
     @testset "Caught Errors" begin
@@ -65,8 +62,7 @@ using Test
         @test lineintegral(f, rect_traj_ring) ≈ 4sqrt(2)                # Meshes.Ring
         @test lineintegral(f, rect_traj_rope) ≈ 4sqrt(2)                # Meshes.Rope
         @test isapprox(lineintegral(f, unit_circle), 2pi; atol=0.15)    # Meshes.BezierCurve
-        @test isapprox(surfaceintegral(f, triangle2d), 1.0; atol=1e-3)  # Meshes.Triangle
-        @test isapprox(surfaceintegral(f, triangle3d), 1.0; atol=1e-3)  # Meshes.Triangle
+        @test isapprox(surfaceintegral(f, triangle), 1.0; atol=1e-3)    # Meshes.Triangle
     end
 
     @testset "Vector-Valued Functions" begin
@@ -76,8 +72,7 @@ using Test
         @test lineintegral(f, rect_traj_ring) ≈ 4 .* [sqrt(2), sqrt(2), sqrt(2)]   # Meshes.Ring
         @test lineintegral(f, rect_traj_rope) ≈ 4 .* [sqrt(2), sqrt(2), sqrt(2)]   # Meshes.Rope
         @test isapprox(lineintegral(f, unit_circle), [2π, 2π, 2π]; atol=0.15)      # Meshes.BezierCurve
-        @test isapprox(surfaceintegral(f, triangle2d), [1.0, 1.0, 1.0]; atol=1e-3) # Meshes.Triangle
-        @test isapprox(surfaceintegral(f, triangle3d), [1.0, 1.0, 1.0]; atol=1e-3) # Meshes.Triangle
+        @test isapprox(surfaceintegral(f, triangle), [1.0, 1.0, 1.0]; atol=1e-3)   # Meshes.Triangle
     end
 
     @testset "Results Consistent with QuadGK" begin


### PR DESCRIPTION
Updates API to reflect scope expansion to handle more general geometric integrals:
- `integral` now `lineintegral`
- new functions: `surfaceintegral` and `volumeintegral`
- `QuadGK.quadgk` methods now owned as `quadgk_line`, `quadgk_surface`