### PR TITLE
Release v0.16.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.3] - 2025-06-26
+
+### Changed
+
+- Updated compatibility entry for [CoordRefSystems.jl](https://github.com/JuliaEarth/CoordRefSystems.jl) to support v0.17 and v0.18 ([#175](https://github.com/JuliaGeometry/MeshIntegrals.jl/pull/175), [#180](https://github.com/JuliaGeometry/MeshIntegrals.jl/pull/180)).
+
 
 ## [0.16.2] - 2025-03-16
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MeshIntegrals"
 uuid = "dadec2fd-bbe0-4da4-9dbe-476c782c8e47"
-version = "0.16.2"
+version = "0.16.3"
 
 [deps]
 CliffordNumbers = "3998ac73-6bd4-4031-8035-f167dd3ed523"


### PR DESCRIPTION
I would like to get a new version of MeshIntegrals.jl because the CompatHelper PRs to bump the compat bounds of CoordRefSystems.jl fixes incompatibilities with newer versions of Meshes.jl.